### PR TITLE
Use latest version of debian in Dockerfile.template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 # FROM debian doesn't work with `balena push <addr>` on the Pi Zero
 # because the engine does not know to pull the compatible `armv5` images.
 # This file is for local testing only
-FROM balenalib/%%BALENA_ARCH%%-debian:bullseye-run as binaries
+FROM balenalib/%%BALENA_ARCH%%-debian as binaries
 
 RUN apt-get update && apt-get install -y --no-install-recommends systemd
 


### PR DESCRIPTION
This also fixes versioning since the last commit should have left the version at 0.1.0

Change-type: minor