### PR TITLE
Add log priority 'none' to disable service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ services:
     labels:
       # Necessary to give the container access to the journal directories
       io.balena.features.journal-logs: '1'
-    restart: unless_stopped
+    restart: on-failure
 ```
 
 ## Environment variables
 
-| Name             | Description                                                                                                                 | Default Value |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| JOURNAL_UNITS    | Space separated list of [systemd services](https://wiki.archlinux.org/title/systemd#Using_units) from where to collect logs | openvpn       |
-| JOURNAL_IDS      | Space separated list of syslog identifiers from where to collect logs                                                       | kernel        |
-| JOURNAL_LOGLEVEL | Minimal priority of log entries to make them elegible for collection. One of `debug`, `info`, `warn`, `error`               | error         |
+| Name             | Description                                                                                                                                                                                | Default Value |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| JOURNAL_UNITS    | Space separated list of [systemd services](https://wiki.archlinux.org/title/systemd#Using_units) from where to collect logs                                                                | `openvpn`     |
+| JOURNAL_IDS      | Space separated list of syslog identifiers from where to collect logs                                                                                                                      | `kernel`      |
+| JOURNAL_PRIORITY | Minimal priority of log entries to make them elegible for collection. One of `debug`, `info`, `warn`, `error`, `none`. If `none` is used, then the service will shutdown to save resources | error         |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     build: ./
     labels:
       io.balena.features.journal-logs: '1'
-    restart: unless_stopped
+    restart: on-failure


### PR DESCRIPTION
This renames the configuration `JOURNAL_LOGLEVEL` to `JOURNAL_PRIORITY` (`JOURNAL_LOGLEVEL` is still available but deprecated). It also adds a new option for priority: `none`, indicating the service to ignore any log events of any type. If this option is given, the service will shut down to save resources.

Change-type: minor